### PR TITLE
rbtree.rs - add support for searching neighbors

### DIFF
--- a/arch/um/Makefile
+++ b/arch/um/Makefile
@@ -68,6 +68,8 @@ KBUILD_CFLAGS += $(CFLAGS) $(CFLAGS-y) -D__arch_um__ \
 	-Din6addr_loopback=kernel_in6addr_loopback \
 	-Din6addr_any=kernel_in6addr_any -Dstrrchr=kernel_strrchr
 
+KBUILD_RUSTFLAGS += -Crelocation-model=pie
+
 KBUILD_AFLAGS += $(ARCH_INCLUDE)
 
 USER_CFLAGS = $(patsubst $(KERNEL_DEFINES),,$(patsubst -I%,,$(KBUILD_CFLAGS))) \

--- a/arch/x86/Makefile.um
+++ b/arch/x86/Makefile.um
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: GPL-2.0
 core-y += arch/x86/crypto/
 
+#
+# Disable SSE and other FP/SIMD instructions to match normal x86
+#
+KBUILD_CFLAGS += -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx
+KBUILD_RUSTFLAGS += -Ctarget-feature=-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2
+
 ifeq ($(CONFIG_X86_32),y)
 START := 0x8048000
 

--- a/drivers/gpio/gpio_pl061_rust.rs
+++ b/drivers/gpio/gpio_pl061_rust.rs
@@ -282,7 +282,7 @@ impl amba::Driver for PL061Device {
         )?;
 
         // SAFETY: General part of the data is pinned when `data` is.
-        let gen_inner = unsafe { data.as_mut().map_unchecked_mut(|d| &mut (**d).inner) };
+        let gen_inner = unsafe { data.as_mut().map_unchecked_mut(|d| &mut d.inner) };
         kernel::rawspinlock_init!(gen_inner, "PL061Data::inner");
 
         let data = Arc::<DeviceData>::from(data);

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -107,7 +107,7 @@ pub use build_error::build_error;
 pub use crate::error::{to_result, Error, Result};
 pub use crate::types::{
     bit, bits_iter, ARef, AlwaysRefCounted, Bit, Bool, Either, Either::Left, Either::Right, False,
-    Mode, Opaque, PointerWrapper, ScopeGuard, True,
+    ForeignOwnable, Mode, Opaque, ScopeGuard, True,
 };
 
 use core::marker::PhantomData;

--- a/rust/kernel/linked_list.rs
+++ b/rust/kernel/linked_list.rs
@@ -10,7 +10,7 @@ use core::ptr::NonNull;
 pub use crate::raw_list::{Cursor, GetLinks, Links};
 use crate::{raw_list, raw_list::RawList, sync::Arc};
 
-// TODO: Use the one from `kernel::file_operations::PointerWrapper` instead.
+// TODO: Use the one from `kernel::file_operations::ForeignOwnable` instead.
 /// Wraps an object to be inserted in a linked list.
 pub trait Wrapper<T: ?Sized> {
     /// Converts the wrapped object into a pointer that represents it.

--- a/rust/kernel/platform.rs
+++ b/rust/kernel/platform.rs
@@ -14,7 +14,7 @@ use crate::{
     of,
     str::CStr,
     to_result,
-    types::PointerWrapper,
+    types::ForeignOwnable,
     ThisModule,
 };
 
@@ -101,7 +101,7 @@ impl<T: Driver> Adapter<T> {
             let info = Self::get_id_info(&dev);
             let data = T::probe(&mut dev, info)?;
             // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
-            unsafe { bindings::platform_set_drvdata(pdev, data.into_pointer() as _) };
+            unsafe { bindings::platform_set_drvdata(pdev, data.into_foreign() as _) };
             Ok(0)
         }
     }
@@ -111,12 +111,12 @@ impl<T: Driver> Adapter<T> {
             // SAFETY: `pdev` is guaranteed to be a valid, non-null pointer.
             let ptr = unsafe { bindings::platform_get_drvdata(pdev) };
             // SAFETY:
-            //   - we allocated this pointer using `T::Data::into_pointer`,
+            //   - we allocated this pointer using `T::Data::into_foreign`,
             //     so it is safe to turn back into a `T::Data`.
             //   - the allocation happened in `probe`, no-one freed the memory,
             //     `remove` is the canonical kernel location to free driver data. so OK
             //     to convert the pointer back to a Rust structure here.
-            let data = unsafe { T::Data::from_pointer(ptr) };
+            let data = unsafe { T::Data::from_foreign(ptr) };
             let ret = T::remove(&data);
             <T::Data as driver::DeviceRemoval>::device_remove(&data);
             ret?;
@@ -132,9 +132,9 @@ pub trait Driver {
     /// Corresponds to the data set or retrieved via the kernel's
     /// `platform_{set,get}_drvdata()` functions.
     ///
-    /// Require that `Data` implements `PointerWrapper`. We guarantee to
+    /// Require that `Data` implements `ForeignOwnable`. We guarantee to
     /// never move the underlying wrapped data structure. This allows
-    type Data: PointerWrapper + Send + Sync + driver::DeviceRemoval = ();
+    type Data: ForeignOwnable + Send + Sync + driver::DeviceRemoval = ();
 
     /// The type holding information about each device id supported by the driver.
     type IdInfo: 'static = ();

--- a/rust/kernel/task.rs
+++ b/rust/kernel/task.rs
@@ -5,7 +5,7 @@
 //! C header: [`include/linux/sched.h`](../../../../include/linux/sched.h).
 
 use crate::{
-    bindings, c_str, error::from_kernel_err_ptr, types::PointerWrapper, ARef, AlwaysRefCounted,
+    bindings, c_str, error::from_kernel_err_ptr, types::ForeignOwnable, ARef, AlwaysRefCounted,
     Result, ScopeGuard,
 };
 use alloc::boxed::Box;
@@ -152,16 +152,16 @@ impl Task {
         ) -> core::ffi::c_int {
             // SAFETY: The thread argument is always a `Box<T>` because it is only called via the
             // thread creation below.
-            let bfunc = unsafe { Box::<T>::from_pointer(arg) };
+            let bfunc = unsafe { Box::<T>::from_foreign(arg) };
             bfunc();
             0
         }
 
-        let arg = Box::try_new(func)?.into_pointer();
+        let arg = Box::try_new(func)?.into_foreign();
 
-        // SAFETY: `arg` was just created with a call to `into_pointer` above.
+        // SAFETY: `arg` was just created with a call to `into_foreign` above.
         let guard = ScopeGuard::new(|| unsafe {
-            Box::<T>::from_pointer(arg);
+            Box::<T>::from_foreign(arg);
         });
 
         // SAFETY: The function pointer is always valid (as long as the module remains loaded).

--- a/scripts/rustdoc_test_gen.rs
+++ b/scripts/rustdoc_test_gen.rs
@@ -31,7 +31,7 @@ fn main() {
             rust_tests,
             r#"/// Generated `{name}` KUnit test case from a Rust documentation test.
 #[no_mangle]
-pub fn {name}(__kunit_test: *mut kernel::bindings::kunit) {{
+pub extern "C" fn {name}(__kunit_test: *mut kernel::bindings::kunit) {{
     /// Provides mutual exclusion (see `# Implementation` notes).
     static __KUNIT_TEST_MUTEX: kernel::sync::smutex::Mutex<()> =
         kernel::sync::smutex::Mutex::new(());


### PR DESCRIPTION
Introduce various methods to search for neighboring nodes by key:

- predecessor/successor - prev/next node, in sort order, of an extant node
- lower_bound/upper_bound - next largest/smallest node given a bound
- get_or_lower_bound/get_or_upper_bound - get the given key, else the lower/upper bound of that key